### PR TITLE
Refine EnergyLens landing hero and trust sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Alle sichtbaren, funktionalen oder relevanten Änderungen an der EnergyLens-Land
 ## [Unreleased]
 
 - Landingpage entlang `DESIGN.md` sichtbar verfeinert: Hero-Headline, App-Screenshot-Inszenierung, Energie-/Preis-Signature, Preview-Texte und Tibber-Trust-Sektion.
+- Widget-Claims vereinheitlicht: Homescreen-Widgets werden konsistent als geplant/Roadmap kommuniziert.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Alle sichtbaren, funktionalen oder relevanten Änderungen an der EnergyLens-Land
 
 ## [Unreleased]
 
+- Landingpage entlang `DESIGN.md` sichtbar verfeinert: Hero-Headline, App-Screenshot-Inszenierung, Energie-/Preis-Signature, Preview-Texte und Tibber-Trust-Sektion.
+
 ---
 
 ## 2026-05-24 — Hygiene-Fix: CHANGELOG.md, DEPLOYMENT.md, FALLBACK.md angelegt

--- a/site/assets/css/styles.css
+++ b/site/assets/css/styles.css
@@ -16,7 +16,9 @@
   --accent:    #22d3a5;
   --accent-dk: #16a37e;
   --accent-bg: rgba(34,211,165,0.08);
+  --accent-line: rgba(34,211,165,0.36);
   --warm:      #f59e0b;
+  --warm-bg:   rgba(245,158,11,0.12);
   --font: 'Inter', system-ui, -apple-system, sans-serif;
 }
 
@@ -110,6 +112,30 @@ body {
   overflow: hidden;
   padding: 120px 32px 80px;
 }
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -20% -10% auto auto;
+  width: min(720px, 80vw);
+  aspect-ratio: 1;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(34,211,165,0.16), transparent 36%),
+    conic-gradient(from 165deg, transparent 0deg, rgba(34,211,165,0.22) 44deg, transparent 86deg, rgba(245,158,11,0.16) 132deg, transparent 190deg);
+  filter: blur(8px);
+  opacity: 0.72;
+  pointer-events: none;
+}
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: radial-gradient(circle at 72% 40%, black 0%, transparent 58%);
+  pointer-events: none;
+}
 .hero-glow {
   position: absolute;
   top: -200px; left: 50%;
@@ -126,6 +152,8 @@ body {
   gap: 80px;
   align-items: center;
   width: 100%;
+  position: relative;
+  z-index: 1;
 }
 .hero-copy { display: flex; flex-direction: column; gap: 28px; }
 .hero-eyebrow {
@@ -162,6 +190,25 @@ body {
 }
 .hero-actions { display: flex; gap: 12px; flex-wrap: wrap; }
 
+.hero-proof {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  max-width: 520px;
+}
+.hero-proof span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 999px;
+  background: rgba(15,24,36,0.72);
+  color: var(--text-2);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
 .app-store-btn {
   display: inline-flex;
   align-items: center;
@@ -183,6 +230,78 @@ body {
   justify-content: center;
   align-items: center;
   position: relative;
+}
+.hero-device-stage {
+  position: relative;
+  width: min(420px, 100%);
+  min-height: 560px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hero-device-stage::before,
+.hero-device-stage::after {
+  content: '';
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.hero-device-stage::before {
+  width: 390px;
+  aspect-ratio: 1;
+  border: 1px solid var(--accent-line);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(34,211,165,0.12), transparent 57%),
+    conic-gradient(from 24deg, rgba(34,211,165,0.32), transparent 28%, rgba(245,158,11,0.18), transparent 64%, rgba(34,211,165,0.24));
+  box-shadow: 0 0 70px rgba(34,211,165,0.12);
+}
+.hero-device-stage::after {
+  width: 285px;
+  aspect-ratio: 1;
+  border: 1px dashed rgba(255,255,255,0.12);
+}
+.hero-phone {
+  width: 282px;
+  transform: rotate(-2deg);
+}
+.hero-meter-card {
+  position: absolute;
+  z-index: 3;
+  width: 150px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 18px;
+  background: rgba(15,24,36,0.78);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: 0 22px 60px rgba(0,0,0,0.36);
+}
+.hero-meter-card span {
+  display: block;
+  color: var(--text-2);
+  font-size: 0.72rem;
+  font-weight: 600;
+  margin-bottom: 5px;
+}
+.hero-meter-card strong {
+  color: var(--text);
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+.hero-meter-card--price {
+  top: 82px;
+  left: 4px;
+}
+.hero-meter-card--saving {
+  right: -2px;
+  bottom: 104px;
+  border-color: rgba(245,158,11,0.24);
+  background: linear-gradient(135deg, rgba(245,158,11,0.16), rgba(15,24,36,0.82));
+}
+.hero-meter-card--saving span {
+  color: rgba(255,255,255,0.72);
 }
 .phone-mockup {
   position: relative;
@@ -255,6 +374,16 @@ body {
   color: var(--muted);
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+.preview-copy {
+  text-align: center;
+  max-width: 180px;
+}
+.preview-copy span {
+  display: block;
+  color: var(--text-2);
+  font-size: 0.84rem;
+  line-height: 1.5;
 }
 
 /* ── Stats bar ── */
@@ -393,6 +522,57 @@ body {
   background: var(--accent);
   flex-shrink: 0;
 }
+.trust-section {
+  background:
+    radial-gradient(circle at 16% 18%, rgba(34,211,165,0.08), transparent 32%),
+    var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.trust-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.86fr);
+  gap: 64px;
+  align-items: center;
+}
+.trust-copy {
+  color: var(--text-2);
+  line-height: 1.7;
+  margin-top: 16px;
+}
+.trust-card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.trust-card {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 24px;
+  border: 1px solid rgba(255,255,255,0.09);
+  border-radius: 18px;
+  background: rgba(8,13,20,0.42);
+  box-shadow: 0 18px 56px rgba(0,0,0,0.18);
+}
+.trust-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: var(--accent-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.trust-card strong {
+  font-size: 0.95rem;
+}
+.trust-card p {
+  color: var(--text-2);
+  font-size: 0.86rem;
+  margin-top: 4px;
+}
 
 /* ── CTA section ── */
 .cta-section {
@@ -415,6 +595,12 @@ body {
   letter-spacing: -0.02em;
 }
 .cta-inner p { color: var(--text-2); font-size: 1rem; }
+.cta-icon {
+  width: 80px;
+  height: 80px;
+  border-radius: 18px;
+  box-shadow: 0 18px 50px rgba(34,211,165,0.16);
+}
 
 /* ── Footer ── */
 .site-footer {
@@ -457,11 +643,45 @@ body {
   .hero-copy { align-items: center; }
   .hero-sub { text-align: center; }
   .hero-visual { order: -1; }
+  .hero-device-stage { min-height: 460px; width: min(360px, 100%); }
+  .hero-device-stage::before { width: 320px; }
+  .hero-device-stage::after { width: 230px; }
+  .hero-phone { width: 228px; }
+  .hero-meter-card { width: 132px; padding: 11px 12px; }
+  .hero-meter-card--price { top: 50px; left: 0; }
+  .hero-meter-card--saving { right: 0; bottom: 72px; }
+  .hero-proof { justify-content: center; }
   .app-icon { width: 160px; height: 160px; border-radius: 36px; }
   .feature-grid { grid-template-columns: 1fr; }
+  .trust-layout { grid-template-columns: 1fr; gap: 40px; }
+  .trust-section .reveal { text-align: left; }
   .stats-bar__inner { grid-template-columns: 1fr; gap: 24px; }
   .stat-item + .stat-item { border-left: none; border-top: 1px solid var(--border); padding-top: 24px; }
   .site-nav__inner { padding: 0 20px; }
   .section { padding: 64px 20px; }
   .nav-links { gap: 16px; }
+}
+
+@media (max-width: 460px) {
+  .hero { padding-left: 20px; padding-right: 20px; }
+  .hero-actions { justify-content: center; }
+  .hero-device-stage { min-height: 420px; }
+  .hero-meter-card {
+    position: relative;
+    inset: auto;
+    width: 100%;
+    max-width: 228px;
+  }
+  .hero-meter-card--price,
+  .hero-meter-card--saving {
+    position: absolute;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+  .hero-meter-card--price { top: 0; }
+  .hero-meter-card--saving { bottom: 0; }
+  .phone-frame { border-radius: 36px; }
+  .phone-screenshot { border-radius: 28px; }
+  .nav-links { display: none; }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -35,15 +35,13 @@
     <main>
       <!-- Hero -->
       <section class="hero">
-        <div class="hero-glow" aria-hidden="true"></div>
         <div class="hero-inner">
           <div class="hero-copy">
-            <span class="hero-eyebrow">iOS App</span>
-            <h1>Energie verstehen.<br /><em>Kosten im Griff.</em></h1>
+            <span class="hero-eyebrow">EnergyLens für iPhone</span>
+            <h1>Strompreise sehen, bevor sie teuer werden.</h1>
             <p class="hero-sub">
-              EnergyLens bereitet deine Tibber-Energie- und Verbrauchsdaten
-              verständlich auf — für Menschen, die ihre Stromkosten kennen wollen,
-              ohne Ingenieur zu sein.
+              EnergyLens macht Tibber-Preise, Verbrauch und Kostenvergleiche
+              so lesbar, dass du gute Entscheidungen direkt im Alltag triffst.
             </p>
             <div class="hero-actions">
               <a class="app-store-btn" href="#download">
@@ -57,11 +55,23 @@
               </a>
               <a class="button button-secondary" href="#features">Mehr erfahren</a>
             </div>
+            <div class="hero-proof" aria-label="Produktvertrauen">
+              <span>Lokal gespeicherter Tibber-Token</span>
+              <span>iOS 17+</span>
+              <span>Widgets geplant</span>
+            </div>
           </div>
           <div class="hero-visual">
-            <div class="phone-mockup">
-              <div class="phone-glow" aria-hidden="true"></div>
-              <div class="phone-frame">
+            <div class="hero-device-stage">
+              <div class="hero-meter-card hero-meter-card--price">
+                <span>Günstigste Stunde</span>
+                <strong>14:00</strong>
+              </div>
+              <div class="hero-meter-card hero-meter-card--saving">
+                <span>Heute im Blick</span>
+                <strong>Preis + Verbrauch</strong>
+              </div>
+              <div class="phone-frame hero-phone">
                 <img class="phone-screenshot" src="./assets/images/screenshot-dashboard.png" alt="EnergyLens Dashboard" />
               </div>
             </div>
@@ -82,25 +92,37 @@
               <div class="phone-frame phone-light">
                 <img class="phone-screenshot" src="./assets/images/screenshot-dashboard.png" alt="EnergyLens Light Mode" />
               </div>
-              <p class="preview-label">Light Mode</p>
+              <div class="preview-copy">
+                <p class="preview-label">Dashboard</p>
+                <span>Preise, Verbrauch und Kosten an einem Ort.</span>
+              </div>
             </div>
             <div class="preview-item">
               <div class="phone-frame">
                 <img class="phone-screenshot" src="./assets/images/screenshot-dashboard-dark.png" alt="EnergyLens Dark Mode" />
               </div>
-              <p class="preview-label">Dark Mode</p>
+              <div class="preview-copy">
+                <p class="preview-label">Dark Mode</p>
+                <span>Ruhige Ansicht für jeden Tagesrhythmus.</span>
+              </div>
             </div>
             <div class="preview-item">
               <div class="phone-frame">
                 <img class="phone-screenshot" src="./assets/images/screenshot-beste-zeiten.png" alt="EnergyLens Beste Zeiten" />
               </div>
-              <p class="preview-label">Beste Zeiten</p>
+              <div class="preview-copy">
+                <p class="preview-label">Beste Zeiten</p>
+                <span>Lade- und Laufzeiten besser planen.</span>
+              </div>
             </div>
             <div class="preview-item">
               <div class="phone-frame">
                 <img class="phone-screenshot" src="./assets/images/screenshot-analyse.png" alt="EnergyLens Analyse" />
               </div>
-              <p class="preview-label">Analyse</p>
+              <div class="preview-copy">
+                <p class="preview-label">Analyse</p>
+                <span>Monate vergleichen und Muster erkennen.</span>
+              </div>
             </div>
           </div>
         </div>
@@ -169,52 +191,52 @@
       </section>
 
       <!-- Tibber Integration -->
-      <section class="section" id="tibber" style="background: var(--surface); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border);">
+      <section class="section trust-section" id="tibber">
         <div class="section-inner">
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: center;">
+          <div class="trust-layout">
             <div class="reveal">
               <div class="integration-badge">
                 <span class="dot"></span>
                 Tibber-Integration
               </div>
               <p class="section-kicker">Voraussetzung</p>
-              <h2 style="margin-bottom: 20px;">Gemacht für Tibber-Kunden.</h2>
-              <p style="color: var(--text-2); line-height: 1.7; margin-bottom: 16px;">
+              <h2>Gemacht für Tibber-Kunden.</h2>
+              <p class="trust-copy">
                 EnergyLens ist speziell für Nutzer des Tibber-Stromtarifs entwickelt.
                 Die App greift per API auf deine Verbrauchsdaten zu — sicher,
                 ohne dass Zugangsdaten gespeichert werden.
               </p>
-              <p style="color: var(--text-2); line-height: 1.7;">
+              <p class="trust-copy">
                 Noch kein Tibber-Kunde? Mit unserem Empfehlungslink bekommt
                 ihr beide einen Startbonus.
               </p>
             </div>
-            <div class="reveal" style="display: flex; flex-direction: column; gap: 16px;">
-              <div style="background: var(--bg); border: 1px solid var(--border); border-radius: 16px; padding: 24px; display: flex; gap: 16px; align-items: flex-start;">
-                <div style="width: 40px; height: 40px; background: var(--accent-bg); border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+            <div class="trust-card-stack reveal">
+              <div class="trust-card">
+                <div class="trust-icon">
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                 </div>
                 <div>
-                  <strong style="font-size: 0.95rem;">Sicher & privat</strong>
-                  <p style="font-size: 0.85rem; color: var(--text-2); margin-top: 4px;">Dein Tibber-Token wird ausschließlich lokal auf deinem Gerät gespeichert.</p>
+                  <strong>Sicher & privat</strong>
+                  <p>Dein Tibber-Token wird ausschließlich lokal auf deinem Gerät gespeichert.</p>
                 </div>
               </div>
-              <div style="background: var(--bg); border: 1px solid var(--border); border-radius: 16px; padding: 24px; display: flex; gap: 16px; align-items: flex-start;">
-                <div style="width: 40px; height: 40px; background: var(--accent-bg); border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.8" stroke-linecap: round; stroke-linejoin: round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+              <div class="trust-card">
+                <div class="trust-icon">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
                 </div>
                 <div>
-                  <strong style="font-size: 0.95rem;">Echtzeit-Daten</strong>
-                  <p style="font-size: 0.85rem; color: var(--text-2); margin-top: 4px;">Strompreise werden direkt von der Tibber GraphQL API geladen — immer aktuell.</p>
+                  <strong>Echtzeit-Daten</strong>
+                  <p>Strompreise werden direkt von der Tibber GraphQL API geladen.</p>
                 </div>
               </div>
-              <div style="background: var(--bg); border: 1px solid var(--border); border-radius: 16px; padding: 24px; display: flex; gap: 16px; align-items: flex-start;">
-                <div style="width: 40px; height: 40px; background: var(--accent-bg); border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+              <div class="trust-card">
+                <div class="trust-icon">
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
                 </div>
                 <div>
-                  <strong style="font-size: 0.95rem;">Automatisch aktuell</strong>
-                  <p style="font-size: 0.85rem; color: var(--text-2); margin-top: 4px;">Hintergrund-Refresh hält Preise und Verbrauchsdaten ohne manuelles Aktualisieren frisch.</p>
+                  <strong>Launch-Status klar</strong>
+                  <p>App Store, iOS-Version und Funktionsumfang bleiben sichtbar eingeordnet.</p>
                 </div>
               </div>
             </div>
@@ -225,10 +247,10 @@
       <!-- CTA -->
       <section class="cta-section" id="download">
         <div class="cta-inner reveal">
-          <img src="./assets/images/app-icon.png" alt="EnergyLens" style="width: 80px; height: 80px; border-radius: 18px;" />
+          <img class="cta-icon" src="./assets/images/app-icon.png" alt="EnergyLens" />
           <h2>Deinen Strom endlich verstehen.</h2>
           <p>EnergyLens ist kostenlos im App Store erhältlich — für iPhones ab iOS 17.</p>
-          <a class="app-store-btn" href="#" style="font-size: 1rem;">
+          <a class="app-store-btn" href="#">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
             </svg>

--- a/site/index.html
+++ b/site/index.html
@@ -141,7 +141,7 @@
           </div>
           <div class="stat-item">
             <span class="stat-number">iOS</span>
-            <span class="stat-label">mit Widget-Unterstützung</span>
+            <span class="stat-label">Widget-Roadmap eingeordnet</span>
           </div>
         </div>
       </div>
@@ -183,8 +183,8 @@
               <div class="feature-icon">
                 <svg viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
               </div>
-              <h3>Widgets für den Homescreen</h3>
-              <p>Aktueller Strompreis und Tagesverbrauch direkt auf dem Homescreen — immer im Blick, ohne die App öffnen zu müssen.</p>
+              <h3>Widgets in Planung</h3>
+              <p>Homescreen-Widgets für Strompreis und Tagesverbrauch sind als nächster Ausbau geplant und werden klar als Roadmap geführt.</p>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Refines the EnergyLens hero around a clearer price and consumption promise.
- Adds a stronger app-led visual stage with proof chips, energy/price cards, and sharper preview copy.
- Reworks the Tibber trust section into structured privacy, realtime data, and launch-status cards.

## User Scenarios
- A Tibber user lands on the page and immediately sees what EnergyLens helps them decide.
- A cautious user can find the local token/privacy claim without digging.
- A mobile visitor can scan the hero, CTA, screenshots, and trust cues without overlap or horizontal scroll.

## Browser-QA
Browser-QA: pass-with-notes
- Tier: standard
- URL: http://127.0.0.1:4177/
- Branch/commit: issue-7-energylens-landing-refine / e137e2f
- Viewports: desktop 1440x1100, mobile 375x900, plus full-page smoke screenshots
- Checks: `git diff --check`, HTML parser smoke, local server 200, critical assets 200, anchor targets valid
- Screenshots: `/tmp/openclaw-energylens-qa/desktop-2.png`, `/tmp/openclaw-energylens-qa/mobile-2.png`, `/tmp/openclaw-energylens-qa/desktop-full.png`, `/tmp/openclaw-energylens-qa/mobile-full.png`
- Notes: Playwright CLI screenshots succeeded. The repo does not expose Playwright as a local Node dependency, so console/network coverage used local server + asset/anchor checks rather than a project-owned Playwright test file.

## Project Closeout
- `CHANGELOG.md` updated.
- Docs/version: version-neutral static landingpage change; no version file found in repo.
- Doku sync: not applicable for this project repo.
- Cost/Governance: no GitHub AI/Copilot automation or paid GitHub AI review used.

OpenClaw-Repair-Loop: yes
Fixes #7
